### PR TITLE
Create dark themed chat and preferences UI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveHouseholdContext } from "@/lib/households";
+import type { RecommendationMovie } from "@/types/db";
+
+type ChatRequestPayload = {
+  message: string;
+  householdId?: string;
+  filters?: { labelKey: string; maxIntensity: number; hardNo: boolean }[];
+  history?: { role: string; content: string }[];
+};
+
+type ChatResponsePayload = {
+  message: string;
+  recommendations?: RecommendationMovie[];
+  id?: string;
+};
+
+async function persistMessage(
+  supabase: ReturnType<typeof createClient>,
+  payload: { householdId: string; role: "user" | "assistant" | "system"; content: string; metadata?: Record<string, unknown> | null }
+) {
+  const { error } = await supabase.from("household_chat_messages").insert({
+    household_id: payload.householdId,
+    role: payload.role,
+    content: payload.content,
+    metadata: payload.metadata ?? null,
+  });
+
+  if (error && (error as { code?: string }).code !== "42P01") {
+    console.error("Failed to persist chat message", error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: ChatRequestPayload;
+  try {
+    body = (await request.json()) as ChatRequestPayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const message = (body.message ?? "").trim();
+  if (!message) {
+    return NextResponse.json({ error: "Message is required" }, { status: 400 });
+  }
+
+  const context = await getActiveHouseholdContext();
+  if (!context) {
+    return NextResponse.json({ error: "Household not found" }, { status: 403 });
+  }
+
+  const targetHouseholdId = body.householdId && body.householdId === context.householdId
+    ? body.householdId
+    : context.householdId;
+
+  await persistMessage(supabase, {
+    householdId: targetHouseholdId,
+    role: "user",
+    content: message,
+    metadata: { filters: body.filters, history: body.history },
+  });
+
+  const webhookUrl = process.env.N8N_CHAT_WEBHOOK_URL;
+  let responsePayload: ChatResponsePayload = {
+    message: "I’m ready when you are! (No agent configured yet.)",
+  };
+
+  if (webhookUrl) {
+    try {
+      const webhookResponse = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message,
+          householdId: targetHouseholdId,
+          filters: body.filters,
+          history: body.history,
+        }),
+      });
+
+      const rawText = await webhookResponse.text();
+      if (!webhookResponse.ok) {
+        throw new Error(rawText || `Webhook error: ${webhookResponse.status}`);
+      }
+
+      try {
+        const parsed = JSON.parse(rawText) as ChatResponsePayload;
+        responsePayload = {
+          message: typeof parsed.message === "string" ? parsed.message : rawText,
+          recommendations: Array.isArray(parsed.recommendations) ? parsed.recommendations : undefined,
+          id: parsed.id,
+        };
+      } catch {
+        responsePayload = { message: rawText };
+      }
+    } catch (error) {
+      console.error("Chat webhook failed", error);
+      responsePayload = {
+        message: "The movie assistant is unavailable right now. Please try again shortly.",
+      };
+    }
+  } else {
+    responsePayload = {
+      message: `Preview response: you said “${message}”. Configure N8n to enable full conversations.`,
+    };
+  }
+
+  await persistMessage(supabase, {
+    householdId: targetHouseholdId,
+    role: "assistant",
+    content: responsePayload.message,
+    metadata: responsePayload.recommendations ? { recommendations: responsePayload.recommendations } : null,
+  });
+
+  return NextResponse.json(responsePayload);
+}

--- a/app/api/log-movie/route.ts
+++ b/app/api/log-movie/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveHouseholdContext } from "@/lib/households";
+
+type LogMoviePayload = {
+  movieId: string;
+  watchDate?: string;
+  watchedBy?: string[];
+  rating?: number | null;
+  householdId?: string;
+};
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: LogMoviePayload;
+  try {
+    body = (await request.json()) as LogMoviePayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  if (!body.movieId) {
+    return NextResponse.json({ error: "movieId is required" }, { status: 400 });
+  }
+
+  const context = await getActiveHouseholdContext();
+  if (!context) {
+    return NextResponse.json({ error: "Household not found" }, { status: 403 });
+  }
+
+  const targetHouseholdId = body.householdId && body.householdId === context.householdId
+    ? body.householdId
+    : context.householdId;
+
+  const payload = {
+    movieId: body.movieId,
+    watchDate: body.watchDate,
+    watchedBy: Array.isArray(body.watchedBy) ? body.watchedBy : undefined,
+    rating: typeof body.rating === "number" ? body.rating : undefined,
+    householdId: targetHouseholdId,
+  };
+
+  const webhookUrl = process.env.N8N_LOG_MOVIE_WEBHOOK_URL;
+  if (webhookUrl) {
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Webhook error: ${response.status}`);
+      }
+    } catch (error) {
+      console.error("Log movie webhook failed", error);
+      return NextResponse.json({ error: "Unable to log the movie right now" }, { status: 502 });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/recommendations/do-not-recommend/route.ts
+++ b/app/api/recommendations/do-not-recommend/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveHouseholdContext } from "@/lib/households";
+
+type BlockPayload = {
+  movieId: string;
+  householdId?: string;
+};
+
+export async function POST(request: NextRequest) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: BlockPayload;
+  try {
+    body = (await request.json()) as BlockPayload;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  if (!body.movieId) {
+    return NextResponse.json({ error: "movieId is required" }, { status: 400 });
+  }
+
+  const context = await getActiveHouseholdContext();
+  if (!context) {
+    return NextResponse.json({ error: "Household not found" }, { status: 403 });
+  }
+
+  const targetHouseholdId = body.householdId && body.householdId === context.householdId
+    ? body.householdId
+    : context.householdId;
+
+  const webhookUrl = process.env.N8N_BLOCK_RECOMMENDATION_WEBHOOK_URL;
+  if (webhookUrl) {
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ movieId: body.movieId, householdId: targetHouseholdId }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Webhook error: ${response.status}`);
+      }
+    } catch (error) {
+      console.error("Do-not-recommend webhook failed", error);
+      return NextResponse.json({ error: "Unable to update preferences" }, { status: 502 });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,198 @@
+:root {
+  color-scheme: dark;
+  --gradient-top: #111a2c;
+  --gradient-bottom: #05070f;
+  --surface-1: rgba(14, 19, 31, 0.85);
+  --surface-2: rgba(25, 33, 50, 0.55);
+  --surface-border: rgba(255, 255, 255, 0.08);
+  --text-primary: #f4f6fb;
+  --text-muted: #9ca6bf;
+  --accent: #f97316;
+  --accent-soft: rgba(249, 115, 22, 0.15);
+  --success: #34d399;
+  --danger: #f87171;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  background: radial-gradient(120% 120% at 50% -10%, var(--gradient-top) 0%, var(--gradient-bottom) 80%);
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 1.6rem 2.4rem 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.app-brand {
+  font-weight: 700;
+  font-size: 1.15rem;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.app-nav a {
+  color: var(--text-muted);
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-nav a:hover,
+.app-nav a:focus-visible {
+  color: var(--text-primary);
+  background-color: rgba(255, 255, 255, 0.08);
+  outline: none;
+}
+
+.app-main {
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.6rem 1.3rem;
+  background: var(--accent);
+  color: #0c111f;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.25);
+}
+
+button:hover:not(:disabled),
+button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(249, 115, 22, 0.35);
+  outline: none;
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  box-shadow: none;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+button.secondary:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--surface-border);
+  background: rgba(10, 15, 24, 0.65);
+  color: var(--text-primary);
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.25);
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--surface-border);
+  margin: 1.25rem 0;
+}
+
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.2rem;
+  padding: 1.4rem;
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 30px rgba(7, 9, 15, 0.35);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    padding: 1.3rem 1.1rem 1rem;
+  }
+
+  .app-main {
+    padding: 0 1.1rem 2.5rem;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,37 @@
-export const metadata = { title: "Family Movies (Beta)" };
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import "./globals.css";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export const metadata = { title: "Family Movies" };
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
   return (
     <html lang="en">
-      <body style={{ fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial" }}>
-        <main style={{ maxWidth: 980, margin: "2rem auto", padding: "0 1rem" }}>
-          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
-            <h1 style={{ fontSize: 20, fontWeight: 700 }}>Family Movies (Beta)</h1>
-            <nav style={{ display: "flex", gap: 12 }}>
-              <a href="/">Catalog</a>
-              <a href="/login">Login</a>
+      <body>
+        <div className="app-shell">
+          <header className="app-header">
+            <Link href="/" className="app-brand">
+              <span role="img" aria-hidden>
+                🍿
+              </span>
+              Family Movie Night
+            </Link>
+            <nav className="app-nav">
+              <Link href="/">Chat</Link>
+              <Link href="/preferences">Preferences</Link>
+              {user ? (
+                <span className="badge">{user.email ?? "Signed in"}</span>
+              ) : (
+                <Link href="/login">Sign in</Link>
+              )}
             </nav>
           </header>
-          {children}
-        </main>
+          <main className="app-main">{children}</main>
+        </div>
       </body>
     </html>
   );
 }
-

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,17 +2,18 @@ import { sendMagicLink } from "./actions";
 
 export default function LoginPage() {
   return (
-    <div style={{ maxWidth: 420 }}>
-      <h2>Sign in</h2>
-      <p>We’ll email you a one-time magic link.</p>
-      <form action={sendMagicLink} style={{ display: "grid", gap: 12, marginTop: 12 }}>
-        <input type="email" name="email" placeholder="you@example.com" required
-               style={{ padding: 10, border: "1px solid #ccc", borderRadius: 8 }}/>
-        <button type="submit" style={{ padding: "10px 14px", borderRadius: 8, fontWeight: 600 }}>
-          Send magic link
-        </button>
+    <div className="card" style={{ maxWidth: 420, margin: "3rem auto", display: "grid", gap: "1rem" }}>
+      <div>
+        <h2 style={{ margin: 0 }}>Sign in</h2>
+        <p style={{ color: "var(--text-muted)", marginTop: "0.4rem" }}>
+          We’ll email you a one-time magic link so you can pick up where you left off.
+        </p>
+      </div>
+      <form action={sendMagicLink} style={{ display: "grid", gap: "0.75rem" }}>
+        <input type="email" name="email" placeholder="you@example.com" required />
+        <button type="submit">Send magic link</button>
       </form>
-      <p style={{ fontSize: 12, color: "#666", marginTop: 8 }}>
+      <p style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>
         Check your inbox and open the link on this device.
       </p>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,83 +1,112 @@
+import ChatShell from "@/components/chat/chat-shell";
 import { createClient } from "@/lib/supabase/server";
-import type { CatalogRow } from "@/types/db";
-import { logWatch } from "./actions";
+import { getActiveHouseholdContext, listHouseholdMembers } from "@/lib/households";
+import type { ChatHistoryRow, HouseholdFilterLimit, RecommendationMovie } from "@/types/db";
 
-function MovieCard({ m }: { m: CatalogRow }) {
-  return (
-    <div style={{
-      display: "grid",
-      gridTemplateColumns: "120px 1fr",
-      gap: 12,
-      padding: 12,
-      border: "1px solid #e5e5e5",
-      borderRadius: 12
-    }}>
-      <div style={{ width: 120, height: 180, background: "#f6f6f6", borderRadius: 8, overflow: "hidden" }}>
-        {m.poster_url ? <img src={m.poster_url} alt={m.title} style={{ width: "100%", height: "100%", objectFit: "cover" }}/> : null}
-      </div>
-      <div>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-          <h3 style={{ margin: 0 }}>{m.title}</h3>
-          <span style={{ color: "#666" }}>{m.release_year ?? ""}</span>
-          {m.mpaa_rating ? <span style={{ fontSize: 12, background: "#eee", padding: "2px 6px", borderRadius: 6 }}>{m.mpaa_rating}</span> : null}
-          {m.runtime_minutes ? <span style={{ fontSize: 12, color: "#666" }}>{m.runtime_minutes} min</span> : null}
-        </div>
-        {m.content_labels?.length ? (
-          <div style={{ marginTop: 6, display: "flex", flexWrap: "wrap", gap: 6 }}>
-            {m.content_labels.slice(0, 6).map((l, i) => (
-              <span key={i} style={{ fontSize: 11, background: "#f2f2f2", padding: "2px 6px", borderRadius: 6 }}>
-                {l.key}:{l.intensity}
-              </span>
-            ))}
-          </div>
-        ) : null}
-        {m.providers?.length ? (
-          <div style={{ marginTop: 8, fontSize: 12 }}>
-            Where to watch: {m.providers.map((p, i) => (
-              <a key={i} href={p.link ?? "#"} target="_blank" rel="noreferrer" style={{ marginRight: 8 }}>
-                {p.service}
-              </a>
-            ))}
-          </div>
-        ) : null}
-        <form action={async () => { "use server"; await logWatch(m.id); }}>
-          <button type="submit" style={{ marginTop: 10, padding: "8px 12px", borderRadius: 8, fontWeight: 600 }}>
-            Log watched
-          </button>
-        </form>
-      </div>
-    </div>
-  );
+async function fetchFilters(householdId: string): Promise<HouseholdFilterLimit[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("household_filter_limits")
+    .select("label_key, max_intensity, hard_no")
+    .eq("household_id", householdId)
+    .order("label_key");
+
+  if (error) {
+    if ((error as { code?: string }).code === "42P01") {
+      return [];
+    }
+    throw error;
+  }
+
+  return (data as HouseholdFilterLimit[]) ?? [];
+}
+
+async function fetchChatHistory(householdId: string): Promise<ChatHistoryRow[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("household_chat_messages")
+    .select("id, created_at, household_id, role, content, metadata")
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: true })
+    .limit(40);
+
+  if (error) {
+    if ((error as { code?: string }).code === "42P01") {
+      return [];
+    }
+    throw error;
+  }
+
+  return (data as ChatHistoryRow[]) ?? [];
+}
+
+function mapRecommendations(metadata: Record<string, unknown> | null): RecommendationMovie[] | undefined {
+  if (!metadata) return undefined;
+  const possible = (metadata as { recommendations?: unknown }).recommendations;
+  if (Array.isArray(possible)) {
+    return possible.filter((item): item is RecommendationMovie => {
+      return !!item && typeof item === "object" && "title" in item;
+    });
+  }
+  return undefined;
 }
 
 export default async function Page() {
   const supabase = createClient();
-
-  // Require auth to see catalog (Option A)
   const { data: { user } } = await supabase.auth.getUser();
+
   if (!user) {
     return (
-      <div>
-        <p><strong>Sign in required.</strong> <a href="/login">Go to login</a></p>
-      </div>
+      <section className="card" style={{ maxWidth: 420, margin: "4rem auto" }}>
+        <h2 style={{ marginTop: 0 }}>Sign in required</h2>
+        <p style={{ color: "var(--text-muted)" }}>
+          Sign in with your email to chat with the family movie assistant and manage your filters.
+        </p>
+        <a href="/login">
+          <button type="button">Go to login</button>
+        </a>
+      </section>
     );
   }
 
-  // Pull a small page of catalog rows
-  const { data, error } = await supabase
-    .from("v_movie_catalog")
-    .select("*")
-    .limit(24);
+  const householdContext = await getActiveHouseholdContext();
+  if (!householdContext) {
+    return (
+      <section className="card" style={{ maxWidth: 520, margin: "4rem auto" }}>
+        <h2 style={{ marginTop: 0 }}>Finish onboarding</h2>
+        <p style={{ color: "var(--text-muted)" }}>
+          We couldn’t find a household for your account yet. Complete sign-up by choosing or creating a household,
+          then come back to start chatting.
+        </p>
+      </section>
+    );
+  }
 
-  if (error) return <p style={{ color: "crimson" }}>Error: {error.message}</p>;
-  const rows = (data as unknown as CatalogRow[]) ?? [];
+  const filters = await fetchFilters(householdContext.householdId);
+  const members = await listHouseholdMembers(householdContext.householdId);
+  const history = await fetchChatHistory(householdContext.householdId);
 
-  if (!rows.length) return <p>No movies yet. Add a few via your ingestion job.</p>;
+  const filterSummaries = filters.map((filter) => ({
+    labelKey: filter.label_key,
+    maxIntensity: filter.max_intensity,
+    hardNo: filter.hard_no,
+  }));
+
+  const messages = history.map((row) => ({
+    id: row.id,
+    role: row.role,
+    content: row.content,
+    createdAt: row.created_at,
+    recommendations: mapRecommendations(row.metadata ?? null),
+  }));
 
   return (
-    <div style={{ display: "grid", gap: 12 }}>
-      {rows.map((m) => <MovieCard key={m.id} m={m} />)}
-    </div>
+    <ChatShell
+      householdId={householdContext.householdId}
+      householdName={householdContext.householdName}
+      filters={filterSummaries}
+      members={members}
+      initialMessages={messages}
+    />
   );
 }
-

--- a/app/preferences/actions.ts
+++ b/app/preferences/actions.ts
@@ -1,0 +1,157 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { requireActiveHouseholdContext } from "@/lib/households";
+import { DEFAULT_FILTERS } from "@/lib/filters";
+
+const DEFAULT_INTENSITY = 5;
+
+type ActionResult = { ok: boolean; error?: string };
+
+type UpdatePayload = {
+  labelKey: string;
+  maxIntensity: number;
+  hardNo: boolean;
+};
+
+type BulkAddPayload = {
+  labels: string[];
+};
+
+type BulkRemovePayload = {
+  labels: string[];
+};
+
+function revalidate() {
+  revalidatePath("/preferences");
+  revalidatePath("/");
+}
+
+function sanitizeLabel(label: string): string {
+  return label.trim();
+}
+
+function intensityGuard(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_INTENSITY;
+  const rounded = Math.round(value);
+  return Math.min(10, Math.max(1, rounded));
+}
+
+export async function updateFilter(payload: UpdatePayload): Promise<ActionResult> {
+  const labelKey = sanitizeLabel(payload.labelKey);
+  if (!labelKey) {
+    return { ok: false, error: "Label is required" };
+  }
+
+  const { householdId } = await requireActiveHouseholdContext();
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("household_filter_limits")
+    .upsert({
+      household_id: householdId,
+      label_key: labelKey,
+      hard_no: payload.hardNo,
+      max_intensity: intensityGuard(payload.maxIntensity),
+    }, { onConflict: "household_id,label_key" });
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  revalidate();
+  return { ok: true };
+}
+
+export async function addFilters(payload: BulkAddPayload): Promise<ActionResult> {
+  const labels = (payload.labels ?? []).map(sanitizeLabel).filter(Boolean);
+  if (!labels.length) {
+    return { ok: false, error: "Add at least one filter" };
+  }
+
+  const unique = Array.from(new Map(labels.map((label) => [label.toLowerCase(), label])).values());
+  const { householdId } = await requireActiveHouseholdContext();
+  const supabase = createClient();
+
+  const { data: existingData } = await supabase
+    .from("household_filter_limits")
+    .select("label_key")
+    .eq("household_id", householdId);
+
+  const existing = new Set((existingData ?? []).map((row: { label_key: string }) => row.label_key.toLowerCase()));
+  const rows = unique
+    .filter((label) => !existing.has(label.toLowerCase()))
+    .map((label) => {
+      const preset = DEFAULT_FILTERS.find((filter) => filter.labelKey.toLowerCase() === label.toLowerCase());
+      return {
+        household_id: householdId,
+        label_key: label,
+        hard_no: false,
+        max_intensity: preset?.defaultIntensity ?? DEFAULT_INTENSITY,
+      };
+    });
+
+  if (!rows.length) {
+    return { ok: false, error: "Those filters already exist" };
+  }
+
+  const { error } = await supabase.from("household_filter_limits").insert(rows);
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  revalidate();
+  return { ok: true };
+}
+
+export async function removeFilters(payload: BulkRemovePayload): Promise<ActionResult> {
+  const labels = (payload.labels ?? []).map(sanitizeLabel).filter(Boolean);
+  if (!labels.length) {
+    return { ok: false, error: "Select at least one filter to remove" };
+  }
+
+  const { householdId } = await requireActiveHouseholdContext();
+  const supabase = createClient();
+
+  const { error } = await supabase
+    .from("household_filter_limits")
+    .delete()
+    .eq("household_id", householdId)
+    .in("label_key", labels);
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  revalidate();
+  return { ok: true };
+}
+
+export async function resetFilters(): Promise<ActionResult> {
+  const { householdId } = await requireActiveHouseholdContext();
+  const supabase = createClient();
+
+  const { error: deleteError } = await supabase
+    .from("household_filter_limits")
+    .delete()
+    .eq("household_id", householdId);
+
+  if (deleteError) {
+    return { ok: false, error: deleteError.message };
+  }
+
+  const rows = DEFAULT_FILTERS.map((filter) => ({
+    household_id: householdId,
+    label_key: filter.labelKey,
+    hard_no: false,
+    max_intensity: filter.defaultIntensity,
+  }));
+
+  const { error: insertError } = await supabase.from("household_filter_limits").insert(rows);
+  if (insertError) {
+    return { ok: false, error: insertError.message };
+  }
+
+  revalidate();
+  return { ok: true };
+}

--- a/app/preferences/page.tsx
+++ b/app/preferences/page.tsx
@@ -1,0 +1,62 @@
+import PreferencesPanel from "@/components/preferences/preferences-panel";
+import { createClient } from "@/lib/supabase/server";
+import { getActiveHouseholdContext } from "@/lib/households";
+import type { HouseholdFilterLimit } from "@/types/db";
+
+async function fetchFilters(householdId: string): Promise<HouseholdFilterLimit[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("household_filter_limits")
+    .select("label_key, max_intensity, hard_no")
+    .eq("household_id", householdId)
+    .order("label_key");
+
+  if (error) {
+    if ((error as { code?: string }).code === "42P01") {
+      return [];
+    }
+    throw error;
+  }
+
+  return (data as HouseholdFilterLimit[]) ?? [];
+}
+
+export default async function PreferencesPage() {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return (
+      <section className="card" style={{ maxWidth: 420, margin: "4rem auto" }}>
+        <h2 style={{ marginTop: 0 }}>Sign in to manage filters</h2>
+        <p style={{ color: "var(--text-muted)" }}>
+          Your household filters live in Supabase. Sign in first so we can load and update them securely.
+        </p>
+        <a href="/login">
+          <button type="button">Go to login</button>
+        </a>
+      </section>
+    );
+  }
+
+  const context = await getActiveHouseholdContext();
+  if (!context) {
+    return (
+      <section className="card" style={{ maxWidth: 520, margin: "4rem auto" }}>
+        <h2 style={{ marginTop: 0 }}>No household found</h2>
+        <p style={{ color: "var(--text-muted)" }}>
+          Finish onboarding by joining or creating a household. Once that’s done, you’ll be able to configure filters here.
+        </p>
+      </section>
+    );
+  }
+
+  const filters = await fetchFilters(context.householdId);
+  const filterViews = filters.map((filter) => ({
+    labelKey: filter.label_key,
+    maxIntensity: filter.max_intensity,
+    hardNo: filter.hard_no,
+  }));
+
+  return <PreferencesPanel filters={filterViews} householdName={context.householdName} />;
+}

--- a/components/chat/chat-shell.module.css
+++ b/components/chat/chat-shell.module.css
@@ -1,0 +1,452 @@
+.container {
+  display: grid;
+  gap: 1.6rem;
+}
+
+@media (min-width: 960px) {
+  .container {
+    grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.chatCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.6rem;
+  background: var(--surface-1);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.4rem;
+  box-shadow: 0 18px 30px rgba(5, 7, 12, 0.45);
+  backdrop-filter: blur(16px);
+  min-height: 520px;
+}
+
+.chatHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chatHeaderTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.chatHeaderTitle h1 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.02em;
+}
+
+.chatHeaderTitle span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.connectionBadge {
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--success);
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.connectionDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--success);
+}
+
+.messageLog {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+.messageScroller {
+  overflow-y: auto;
+  max-height: 60vh;
+  padding-right: 0.4rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+@media (min-width: 960px) {
+  .messageScroller {
+    max-height: calc(80vh - 220px);
+  }
+}
+
+.messageGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.messageRow {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.messageRowUser {
+  justify-content: flex-end;
+}
+
+.messageBubble {
+  max-width: min(540px, 85%);
+  padding: 0.9rem 1.1rem;
+  border-radius: 1.1rem;
+  position: relative;
+  white-space: pre-wrap;
+  line-height: 1.55;
+  font-size: 0.95rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.userBubble {
+  background: var(--accent);
+  color: #091020;
+  border-bottom-right-radius: 0.45rem;
+}
+
+.assistantBubble {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom-left-radius: 0.45rem;
+}
+
+.systemBubble {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--success);
+  border: 1px solid rgba(52, 211, 153, 0.25);
+  margin: 0 auto;
+}
+
+.messageTimestamp {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+}
+
+.pendingDotContainer {
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.pendingDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  animation: pulse 1.1s ease-in-out infinite;
+}
+
+.pendingDot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.pendingDot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  50% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+.recommendations {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.recommendationCard {
+  display: grid;
+  grid-template-columns: 94px 1fr;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 1rem;
+  background: rgba(18, 23, 35, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.posterPlaceholder {
+  width: 94px;
+  height: 140px;
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.06);
+  display: grid;
+  place-items: center;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.posterImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0.8rem;
+}
+
+.recommendationMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.recommendationMeta h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+.recommendationMeta p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.recommendationActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.recommendationActions button {
+  padding: 0.45rem 0.95rem;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  box-shadow: none;
+}
+
+.recommendationActions button.secondary {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.recommendationLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  font-size: 0.78rem;
+}
+
+.recommendationLinks a {
+  color: var(--text-muted);
+}
+
+.composer {
+  background: rgba(10, 15, 24, 0.65);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+textarea.composerInput {
+  width: 100%;
+  min-height: 90px;
+  resize: vertical;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.75rem 0.9rem;
+  background: rgba(4, 6, 12, 0.6);
+  color: var(--text-primary);
+}
+
+textarea.composerInput::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.composerActions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.quickActions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.quickActions button {
+  padding: 0.45rem 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+.quickActions button:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.sidebarCard {
+  background: var(--surface-2);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.4rem;
+  padding: 1.4rem;
+  display: grid;
+  gap: 1rem;
+  backdrop-filter: blur(12px);
+}
+
+.sidebarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sidebarHeader h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.filterList {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.filterRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.filterName {
+  font-size: 0.9rem;
+}
+
+.filterIntensity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.hardNoTag {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--danger);
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.feedback {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.feedbackError {
+  color: var(--danger);
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 10, 18, 0.75);
+  backdrop-filter: blur(18px);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 40;
+}
+
+.modalContent {
+  width: min(420px, 100%);
+  background: var(--surface-1);
+  border-radius: 1.4rem;
+  border: 1px solid var(--surface-border);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 20px 50px rgba(5, 7, 14, 0.6);
+}
+
+.modalContent h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.memberChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.memberChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.78rem;
+}
+
+.memberChip input {
+  width: auto;
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: rgba(9, 14, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.8rem 1.1rem;
+  border-radius: 1rem;
+  font-size: 0.85rem;
+  box-shadow: 0 12px 24px rgba(3, 4, 9, 0.55);
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  z-index: 45;
+}
+
+.toastSuccess {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: var(--success);
+}
+
+.toastError {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: var(--danger);
+}

--- a/components/chat/chat-shell.tsx
+++ b/components/chat/chat-shell.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./chat-shell.module.css";
+import LogMovieModal from "./log-movie-modal";
+import { formatFilterLabel } from "@/lib/filters";
+import type { HouseholdMember } from "@/lib/households";
+import type { ChatMessage, RecommendationMovie } from "@/types/db";
+
+type FilterSummary = {
+  labelKey: string;
+  maxIntensity: number;
+  hardNo: boolean;
+  label?: string;
+};
+
+type ChatShellProps = {
+  householdId: string;
+  householdName: string | null;
+  filters: FilterSummary[];
+  members: HouseholdMember[];
+  initialMessages: ChatMessage[];
+};
+
+type ToastState = { kind: "success" | "error"; message: string } | null;
+
+type ChatApiResponse = {
+  id?: string;
+  message: string;
+  recommendations?: RecommendationMovie[];
+};
+
+const QUICK_ACTIONS = [
+  {
+    label: "Recommend something new",
+    prompt: "Recommend a family-friendly movie that matches our current filters.",
+  },
+  {
+    label: "Short movie night",
+    prompt: "Suggest a movie under 100 minutes that fits our household preferences.",
+  },
+  {
+    label: "Log last night's movie",
+    prompt: "We watched [movie title] together last night.",
+  },
+];
+
+function renderContent(content: string) {
+  const parts = content.split(/(https?:\/\/\S+)/g);
+  return parts.map((part, index) => {
+    if (part.startsWith("http://") || part.startsWith("https://")) {
+      return (
+        <a key={index} href={part} target="_blank" rel="noreferrer">
+          {part}
+        </a>
+      );
+    }
+    return <span key={index}>{part}</span>;
+  });
+}
+
+function formatTimeLabel(timestamp: string) {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+export default function ChatShell({
+  householdId,
+  householdName,
+  filters,
+  members,
+  initialMessages,
+}: ChatShellProps) {
+  const filterSummaries = useMemo(
+    () =>
+      filters.map((filter) => ({
+        ...filter,
+        label: formatFilterLabel(filter.labelKey),
+      })),
+    [filters]
+  );
+
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [inputValue, setInputValue] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(null);
+  const [modalState, setModalState] = useState<{ open: boolean; movie: RecommendationMovie | null }>({
+    open: false,
+    movie: null,
+  });
+  const [isLoggingMovie, setIsLoggingMovie] = useState(false);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = scrollerRef.current;
+    if (!node) return;
+    node.scrollTo({ top: node.scrollHeight, behavior: "smooth" });
+  }, [messages, pendingMessageId]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 3600);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const showToast = useCallback((kind: "success" | "error", message: string) => {
+    setToast({ kind, message });
+  }, []);
+
+  const removePending = useCallback((pendingId: string) => {
+    setMessages((prev) => prev.filter((message) => message.id !== pendingId));
+  }, []);
+
+  const updateAssistantMessage = useCallback((pendingId: string, assistantMessage: ChatMessage) => {
+    setMessages((prev) => {
+      const withoutPending = prev.filter((message) => message.id !== pendingId);
+      return [...withoutPending, assistantMessage];
+    });
+  }, []);
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isSending) return;
+
+      const userMessage: ChatMessage = {
+        id: `user-${Date.now()}`,
+        role: "user",
+        content: trimmed,
+        createdAt: new Date().toISOString(),
+      };
+
+      setMessages((prev) => [...prev, userMessage]);
+      setInputValue("");
+      setIsSending(true);
+
+      const optimisticAssistantId = `assistant-pending-${Date.now()}`;
+      setPendingMessageId(optimisticAssistantId);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: optimisticAssistantId,
+          role: "assistant",
+          content: "",
+          createdAt: new Date().toISOString(),
+          pending: true,
+        },
+      ]);
+
+      try {
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message: trimmed,
+            householdId,
+            filters: filters.map((filter) => ({
+              labelKey: filter.labelKey,
+              maxIntensity: filter.maxIntensity,
+              hardNo: filter.hardNo,
+            })),
+            history: messages.slice(-8).map((message) => ({ role: message.role, content: message.content })),
+          }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(errorText || "Request failed");
+        }
+
+        const payload = (await response.json()) as ChatApiResponse;
+        const assistantMessage: ChatMessage = {
+          id: payload.id ?? `assistant-${Date.now()}`,
+          role: "assistant",
+          content: payload.message ?? "",
+          createdAt: new Date().toISOString(),
+          recommendations: payload.recommendations,
+        };
+        updateAssistantMessage(optimisticAssistantId, assistantMessage);
+      } catch (error) {
+        removePending(optimisticAssistantId);
+        showToast("error", "We couldn't reach the movie assistant. Please try again.");
+      } finally {
+        setPendingMessageId(null);
+        setIsSending(false);
+      }
+    },
+    [filters, householdId, isSending, messages, removePending, showToast, updateAssistantMessage]
+  );
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    sendMessage(inputValue);
+  };
+
+  const handleQuickAction = (prompt: string) => {
+    sendMessage(prompt);
+  };
+
+  const openLogModal = (movie: RecommendationMovie) => {
+    setModalState({ open: true, movie });
+  };
+
+  const closeLogModal = () => {
+    setModalState({ open: false, movie: null });
+  };
+
+  const handleLogMovie = async (input: { movieId: string; watchDate: string; watchedBy: string[]; rating: number | null }) => {
+    setIsLoggingMovie(true);
+    try {
+      const response = await fetch("/api/log-movie", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...input,
+          householdId,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(errorBody || "Failed to log movie");
+      }
+
+      showToast("success", "Saved to your family log.");
+      closeLogModal();
+    } catch (error) {
+      showToast("error", "Unable to log the movie right now.");
+    } finally {
+      setIsLoggingMovie(false);
+    }
+  };
+
+  const handleBlockRecommendation = async (movie: RecommendationMovie) => {
+    try {
+      const response = await fetch("/api/recommendations/do-not-recommend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ movieId: movie.movieId, householdId }),
+      });
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(errorBody || "Request failed");
+      }
+      showToast("success", `We'll skip ${movie.title} going forward.`);
+    } catch (error) {
+      showToast("error", "Couldn't update that preference yet.");
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.container}>
+        <section className={styles.chatCard}>
+          <header className={styles.chatHeader}>
+            <div className={styles.chatHeaderTitle}>
+              <h1>{householdName ? `${householdName} · Movie Concierge` : "Movie Concierge"}</h1>
+              <span>Ask for recommendations, log what you watched, or refine tonight’s plan.</span>
+            </div>
+            <div className={styles.connectionBadge}>
+              <span className={styles.connectionDot} />
+              N8n agent · 3–15s latency
+            </div>
+          </header>
+          <div className={styles.messageLog}>
+            <div ref={scrollerRef} className={styles.messageScroller}>
+              {messages.map((message) => {
+                const bubbleClass =
+                  message.role === "user"
+                    ? styles.userBubble
+                    : message.role === "assistant"
+                    ? styles.assistantBubble
+                    : styles.systemBubble;
+                return (
+                  <div key={message.id} className={`${styles.messageGroup} ${message.role === "user" ? styles.messageRowUser : styles.messageRow}`}>
+                    <div className={`${styles.messageBubble} ${bubbleClass}`}>
+                      {message.pending ? (
+                        <span className={styles.pendingDotContainer}>
+                          <span className={styles.pendingDot} />
+                          <span className={styles.pendingDot} />
+                          <span className={styles.pendingDot} />
+                        </span>
+                      ) : (
+                        renderContent(message.content)
+                      )}
+                      {message.recommendations && message.recommendations.length ? (
+                        <div className={styles.recommendations}>
+                          {message.recommendations.map((movie) => (
+                            <div key={movie.movieId ?? movie.title} className={styles.recommendationCard}>
+                              {movie.posterUrl ? (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img
+                                  src={movie.posterUrl}
+                                  alt={movie.title}
+                                  className={styles.posterImage}
+                                />
+                              ) : (
+                                <div className={styles.posterPlaceholder}>Poster</div>
+                              )}
+                              <div className={styles.recommendationMeta}>
+                                <div>
+                                  <h3>{movie.title}</h3>
+                                  <div style={{ display: "flex", gap: "0.6rem", flexWrap: "wrap", fontSize: "0.78rem", color: "var(--text-muted)" }}>
+                                    {movie.releaseYear ? <span>{movie.releaseYear}</span> : null}
+                                    {movie.mpaaRating ? <span>{movie.mpaaRating}</span> : null}
+                                    {movie.runtimeMinutes ? <span>{movie.runtimeMinutes} min</span> : null}
+                                  </div>
+                                </div>
+                                {movie.overview ? <p>{movie.overview}</p> : null}
+                                {movie.links && movie.links.length ? (
+                                  <div className={styles.recommendationLinks}>
+                                    {movie.links.map((link) => (
+                                      <a key={link.url} href={link.url} target="_blank" rel="noreferrer">
+                                        {link.label}
+                                      </a>
+                                    ))}
+                                  </div>
+                                ) : null}
+                                <div className={styles.recommendationActions}>
+                                  <button type="button" onClick={() => openLogModal(movie)}>
+                                    Mark watched
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="secondary"
+                                    onClick={() => handleBlockRecommendation(movie)}
+                                  >
+                                    Don’t recommend
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    {!message.pending ? (
+                      <span className={styles.messageTimestamp}>{formatTimeLabel(message.createdAt)}</span>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <form className={styles.composer} onSubmit={handleSubmit}>
+            <textarea
+              className={styles.composerInput}
+              placeholder="Ask for family-friendly suggestions or tell the agent what you watched…"
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              disabled={isSending}
+            />
+            <div className={styles.composerActions}>
+              <div className={styles.quickActions}>
+                {QUICK_ACTIONS.map((action) => (
+                  <button
+                    type="button"
+                    key={action.label}
+                    className="secondary"
+                    onClick={() => handleQuickAction(action.prompt)}
+                    disabled={isSending}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+              <button type="submit" disabled={isSending || !inputValue.trim()}>
+                {isSending ? "Sending…" : "Send"}
+              </button>
+            </div>
+          </form>
+        </section>
+        <aside className={styles.sidebarCard}>
+          <div className={styles.sidebarHeader}>
+            <h2>Household filters</h2>
+            <span className="badge">Synced with Supabase</span>
+          </div>
+          <p style={{ margin: 0, fontSize: "0.85rem", color: "var(--text-muted)" }}>
+            Filters help the agent tailor recommendations to your family’s comfort level.
+          </p>
+          <div className={styles.filterList}>
+            {filterSummaries.length ? (
+              filterSummaries.map((filter) => (
+                <div key={filter.labelKey} className={styles.filterRow}>
+                  <div>
+                    <div className={styles.filterName}>{filter.label}</div>
+                    <div className={styles.filterIntensity}>
+                      <span>Intensity</span>
+                      <strong>{filter.maxIntensity}</strong>
+                    </div>
+                  </div>
+                  {filter.hardNo ? <span className={styles.hardNoTag}>Hard no</span> : null}
+                </div>
+              ))
+            ) : (
+              <span style={{ fontSize: "0.82rem", color: "var(--text-muted)" }}>
+                No filters set yet. Add some from the Preferences page.
+              </span>
+            )}
+          </div>
+          <p className={styles.feedback}>
+            Tip: Update filters or intensities any time from the Preferences tab. Changes sync instantly.
+          </p>
+        </aside>
+      </div>
+      <LogMovieModal
+        open={modalState.open}
+        movie={modalState.movie}
+        members={members}
+        pending={isLoggingMovie}
+        onClose={closeLogModal}
+        onConfirm={handleLogMovie}
+      />
+      {toast ? (
+        <div className={`${styles.toast} ${toast.kind === "success" ? styles.toastSuccess : styles.toastError}`}>
+          {toast.message}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/components/chat/log-movie-modal.tsx
+++ b/components/chat/log-movie-modal.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import styles from "./chat-shell.module.css";
+import type { RecommendationMovie } from "@/types/db";
+import type { HouseholdMember } from "@/lib/households";
+
+type LogMovieModalProps = {
+  open: boolean;
+  movie: RecommendationMovie | null;
+  members: HouseholdMember[];
+  pending?: boolean;
+  onClose: () => void;
+  onConfirm: (input: {
+    movieId: string;
+    watchDate: string;
+    watchedBy: string[];
+    rating: number | null;
+  }) => Promise<void> | void;
+};
+
+function todayISO() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatMemberLabel(member: HouseholdMember): string {
+  return member.displayName ?? member.email ?? "Household member";
+}
+
+export default function LogMovieModal({
+  open,
+  movie,
+  members,
+  pending = false,
+  onClose,
+  onConfirm,
+}: LogMovieModalProps) {
+  const [watchDate, setWatchDate] = useState<string>(todayISO());
+  const [rating, setRating] = useState<string>("");
+  const [selectedMembers, setSelectedMembers] = useState<string[]>([]);
+
+  const memberOptions = useMemo(() => members.map((m) => ({ id: m.id, label: formatMemberLabel(m) })), [members]);
+
+  useEffect(() => {
+    if (!open) return;
+    setWatchDate(todayISO());
+    setRating("");
+    setSelectedMembers(memberOptions.map((m) => m.id));
+  }, [open, memberOptions]);
+
+  if (!open || !movie) return null;
+
+  const handleToggleMember = (id: string, checked: boolean) => {
+    setSelectedMembers((prev) => {
+      if (checked) {
+        if (prev.includes(id)) return prev;
+        return [...prev, id];
+      }
+      return prev.filter((memberId) => memberId !== id);
+    });
+  };
+
+  const handleConfirm = async () => {
+    await onConfirm({
+      movieId: movie.movieId,
+      watchDate,
+      watchedBy: selectedMembers,
+      rating: rating ? Number(rating) : null,
+    });
+  };
+
+  return (
+    <div className={styles.modalOverlay} role="dialog" aria-modal aria-labelledby="log-movie-title">
+      <div className={styles.modalContent}>
+        <div>
+          <h3 id="log-movie-title">Log “{movie.title}”</h3>
+          <p style={{ margin: "0.25rem 0", color: "var(--text-muted)", fontSize: "0.85rem" }}>
+            Record who watched this movie and when. N8n will update Supabase for you.
+          </p>
+        </div>
+        <div>
+          <label htmlFor="watch-date">Watch date</label>
+          <input
+            id="watch-date"
+            type="date"
+            value={watchDate}
+            onChange={(event) => setWatchDate(event.target.value)}
+          />
+        </div>
+        <div>
+          <span style={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--text-muted)" }}>Who watched?</span>
+          <div className={styles.memberChips} style={{ marginTop: "0.45rem" }}>
+            {memberOptions.length ? (
+              memberOptions.map((member) => (
+                <label key={member.id} className={styles.memberChip}>
+                  <input
+                    type="checkbox"
+                    checked={selectedMembers.includes(member.id)}
+                    onChange={(event) => handleToggleMember(member.id, event.target.checked)}
+                  />
+                  {member.label}
+                </label>
+              ))
+            ) : (
+              <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>No household members yet.</span>
+            )}
+          </div>
+        </div>
+        <div>
+          <label htmlFor="movie-rating">Family rating</label>
+          <select
+            id="movie-rating"
+            value={rating}
+            onChange={(event) => setRating(event.target.value)}
+          >
+            <option value="">No rating</option>
+            {[1, 2, 3, 4, 5].map((value) => (
+              <option key={value} value={value}>
+                {value} star{value > 1 ? "s" : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={styles.modalActions}>
+          <button type="button" className="secondary" onClick={onClose} disabled={pending}>
+            Cancel
+          </button>
+          <button type="button" onClick={handleConfirm} disabled={pending}>
+            {pending ? "Saving…" : "Log watch"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/preferences/preferences-panel.module.css
+++ b/components/preferences/preferences-panel.module.css
@@ -1,0 +1,192 @@
+.container {
+  display: grid;
+  gap: 1.6rem;
+  background: var(--surface-1);
+  border-radius: 1.4rem;
+  border: 1px solid var(--surface-border);
+  padding: 1.8rem;
+  box-shadow: 0 20px 36px rgba(4, 6, 12, 0.45);
+  backdrop-filter: blur(18px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.actionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.actionsRow button {
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+}
+
+.filtersGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.filterCard {
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 1.1rem;
+  background: rgba(12, 17, 28, 0.65);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.filterHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filterTitle {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.rangeRow {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.sliderRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sliderRow output {
+  min-width: 2.2rem;
+  text-align: right;
+  font-weight: 600;
+}
+
+.rangeRow input[type="range"] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.toggleRow input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
+.cardFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cardFooter button {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.8rem;
+}
+
+.bulkBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.bulkBar span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.addForm {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(9, 12, 20, 0.55);
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 1.2rem;
+}
+
+.addForm textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.inlineChips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.inlineChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.78rem;
+}
+
+.feedback {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.feedbackError {
+  color: var(--danger);
+}
+
+.feedbackSuccess {
+  color: var(--success);
+}
+
+.emptyState {
+  padding: 1.1rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.bulkCheckbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1.4rem;
+  }
+}

--- a/components/preferences/preferences-panel.tsx
+++ b/components/preferences/preferences-panel.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import styles from "./preferences-panel.module.css";
+import { addFilters, removeFilters, resetFilters, updateFilter } from "@/app/preferences/actions";
+import { DEFAULT_FILTERS, formatFilterLabel } from "@/lib/filters";
+
+type FilterView = {
+  labelKey: string;
+  maxIntensity: number;
+  hardNo: boolean;
+};
+
+type PreferencesPanelProps = {
+  filters: FilterView[];
+  householdName: string | null;
+};
+
+type ToastState = { kind: "success" | "error"; text: string } | null;
+
+const DEFAULT_INTENSITY = 5;
+
+function cloneFilters(list: FilterView[]): FilterView[] {
+  return list.map((item) => ({ ...item }));
+}
+
+function parseInputList(raw: string): string[] {
+  return raw
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export default function PreferencesPanel({ filters, householdName }: PreferencesPanelProps) {
+  const [filterRows, setFilterRows] = useState<FilterView[]>(filters);
+  const [persistedFilters, setPersistedFilters] = useState<FilterView[]>(filters);
+  const [selectedForRemoval, setSelectedForRemoval] = useState<string[]>([]);
+  const [bulkMode, setBulkMode] = useState(false);
+  const [addInput, setAddInput] = useState("");
+  const [toast, setToast] = useState<ToastState>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setFilterRows(filters);
+    setPersistedFilters(filters);
+    setSelectedForRemoval([]);
+  }, [filters]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 3600);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const formattedFilters = useMemo(
+    () =>
+      filterRows.map((filter) => ({
+        ...filter,
+        label: formatFilterLabel(filter.labelKey),
+      })),
+    [filterRows]
+  );
+
+  const handleIntensityChange = (labelKey: string, value: number) => {
+    setFilterRows((prev) =>
+      prev.map((filter) =>
+        filter.labelKey === labelKey
+          ? { ...filter, maxIntensity: Math.min(10, Math.max(1, Math.round(value))) }
+          : filter
+      )
+    );
+  };
+
+  const handleHardNoToggle = (labelKey: string, checked: boolean) => {
+    setFilterRows((prev) => prev.map((filter) => (filter.labelKey === labelKey ? { ...filter, hardNo: checked } : filter)));
+  };
+
+  const handleSaveFilter = (labelKey: string) => {
+    const snapshot = cloneFilters(filterRows);
+    const target = snapshot.find((filter) => filter.labelKey === labelKey);
+    if (!target) return;
+
+    startTransition(async () => {
+      const result = await updateFilter({
+        labelKey: target.labelKey,
+        maxIntensity: target.maxIntensity,
+        hardNo: target.hardNo,
+      });
+
+      if (!result.ok) {
+        setFilterRows(cloneFilters(persistedFilters));
+        setToast({ kind: "error", text: result.error ?? "Unable to save filter" });
+      } else {
+        setPersistedFilters(snapshot);
+        setToast({ kind: "success", text: "Filter updated" });
+      }
+    });
+  };
+
+  const toggleBulkMode = () => {
+    setBulkMode((previous) => {
+      if (previous) {
+        setSelectedForRemoval([]);
+      }
+      return !previous;
+    });
+  };
+
+  const toggleSelection = (labelKey: string, checked: boolean) => {
+    setSelectedForRemoval((prev) => {
+      if (checked) {
+        if (prev.includes(labelKey)) return prev;
+        return [...prev, labelKey];
+      }
+      return prev.filter((key) => key !== labelKey);
+    });
+  };
+
+  const handleBulkRemove = () => {
+    if (!selectedForRemoval.length) {
+      setToast({ kind: "error", text: "Choose filters to remove" });
+      return;
+    }
+
+    const snapshot = cloneFilters(filterRows);
+    const remaining = snapshot.filter((filter) => !selectedForRemoval.includes(filter.labelKey));
+    setFilterRows(remaining);
+
+    startTransition(async () => {
+      const result = await removeFilters({ labels: selectedForRemoval });
+      if (!result.ok) {
+        setFilterRows(snapshot);
+        setToast({ kind: "error", text: result.error ?? "Unable to remove filters" });
+      } else {
+        setPersistedFilters(remaining);
+        setToast({ kind: "success", text: "Filters removed" });
+      }
+      setSelectedForRemoval([]);
+      setBulkMode(false);
+    });
+  };
+
+  const handleReset = () => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm("Reset filters to the default set?");
+      if (!confirmed) return;
+    }
+    const snapshot = cloneFilters(filterRows);
+    const defaults = DEFAULT_FILTERS.map((filter) => ({
+      labelKey: filter.labelKey,
+      maxIntensity: filter.defaultIntensity,
+      hardNo: false,
+    }));
+
+    setFilterRows(defaults);
+    setSelectedForRemoval([]);
+    setBulkMode(false);
+
+    startTransition(async () => {
+      const result = await resetFilters();
+      if (!result.ok) {
+        setFilterRows(snapshot);
+        setToast({ kind: "error", text: result.error ?? "Unable to reset filters" });
+      } else {
+        setPersistedFilters(defaults);
+        setToast({ kind: "success", text: "Filters reset to defaults" });
+      }
+    });
+  };
+
+  const handleAddFilters = () => {
+    const parsed = parseInputList(addInput);
+    if (!parsed.length) {
+      setToast({ kind: "error", text: "Add at least one filter label" });
+      return;
+    }
+
+    const snapshot = cloneFilters(filterRows);
+    const existingKeys = new Set(snapshot.map((filter) => filter.labelKey.toLowerCase()));
+    const unique = Array.from(new Map(parsed.map((label) => [label.toLowerCase(), label])).values());
+    const newLabels = unique.filter((label) => !existingKeys.has(label.toLowerCase()));
+
+    if (!newLabels.length) {
+      setToast({ kind: "error", text: "Those filters already exist" });
+      return;
+    }
+
+    const newRows = newLabels.map((label) => ({ labelKey: label, maxIntensity: DEFAULT_INTENSITY, hardNo: false }));
+    const optimistic = [...snapshot, ...newRows];
+    setFilterRows(optimistic);
+    setAddInput("");
+
+    startTransition(async () => {
+      const result = await addFilters({ labels: newLabels });
+      if (!result.ok) {
+        setFilterRows(snapshot);
+        setToast({ kind: "error", text: result.error ?? "Unable to add filters" });
+      } else {
+        setPersistedFilters(optimistic);
+        setToast({ kind: "success", text: "Filters added" });
+      }
+    });
+  };
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.header}>
+        <h1>{householdName ? `${householdName} · Preferences` : "Household preferences"}</h1>
+        <p>
+          Fine-tune what the agent recommends. Adjust intensity, toggle hard “no” topics, add new filters, or reset to the
+          default set any time.
+        </p>
+      </div>
+      <div className={styles.actionsRow}>
+        <button type="button" className="secondary" onClick={toggleBulkMode} disabled={isPending}>
+          {bulkMode ? "Cancel bulk remove" : "Bulk remove"}
+        </button>
+        <button type="button" className="secondary" onClick={handleReset} disabled={isPending}>
+          Reset to defaults
+        </button>
+        <span className="badge">Intensity: 1 (low) – 10 (high)</span>
+      </div>
+      {bulkMode ? (
+        <div className={styles.bulkBar}>
+          <span>{selectedForRemoval.length} selected</span>
+          <button type="button" onClick={handleBulkRemove} disabled={!selectedForRemoval.length || isPending}>
+            Remove selected
+          </button>
+        </div>
+      ) : null}
+      <div className={styles.filtersGrid}>
+        {formattedFilters.length ? (
+          formattedFilters.map((filter) => {
+            const isSelected = selectedForRemoval.includes(filter.labelKey);
+            return (
+              <div key={filter.labelKey} className={styles.filterCard}>
+                <div className={styles.filterHeader}>
+                  <span className={styles.filterTitle}>{filter.label}</span>
+                  {bulkMode ? (
+                    <label className={styles.bulkCheckbox}>
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={(event) => toggleSelection(filter.labelKey, event.target.checked)}
+                      />
+                      Select
+                    </label>
+                  ) : null}
+                </div>
+                <div className={styles.rangeRow}>
+                  <div className={styles.sliderRow}>
+                    <label htmlFor={`intensity-${filter.labelKey}`} style={{ flex: 1 }}>
+                      Intensity preference
+                    </label>
+                    <output htmlFor={`intensity-${filter.labelKey}`}>{filter.maxIntensity}</output>
+                  </div>
+                  <input
+                    id={`intensity-${filter.labelKey}`}
+                    type="range"
+                    min={1}
+                    max={10}
+                    step={1}
+                    value={filter.maxIntensity}
+                    onChange={(event) => handleIntensityChange(filter.labelKey, Number(event.target.value))}
+                    disabled={isPending}
+                  />
+                </div>
+                <div className={styles.toggleRow}>
+                  <input
+                    id={`hardno-${filter.labelKey}`}
+                    type="checkbox"
+                    checked={filter.hardNo}
+                    onChange={(event) => handleHardNoToggle(filter.labelKey, event.target.checked)}
+                    disabled={isPending}
+                  />
+                  <label htmlFor={`hardno-${filter.labelKey}`}>Mark as a hard “no”</label>
+                </div>
+                <div className={styles.cardFooter}>
+                  <span className="badge">Key: {filter.labelKey}</span>
+                  <button type="button" onClick={() => handleSaveFilter(filter.labelKey)} disabled={isPending}>
+                    Save changes
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div className={styles.emptyState}>
+            No filters yet. Use the add form below to define the themes and triggers your family cares about.
+          </div>
+        )}
+      </div>
+      <div className={styles.addForm}>
+        <div>
+          <label htmlFor="add-filters">Add multiple filters</label>
+          <p className={styles.feedback} style={{ marginTop: "0.35rem" }}>
+            Separate labels with commas or line breaks. New filters start with intensity {DEFAULT_INTENSITY} and hard “no” off.
+          </p>
+          <textarea
+            id="add-filters"
+            placeholder="e.g. jump_scares, live_action, dragons"
+            value={addInput}
+            onChange={(event) => setAddInput(event.target.value)}
+            disabled={isPending}
+          />
+        </div>
+        <div>
+          <span className={styles.feedback}>Popular defaults:</span>
+          <div className={styles.inlineChips}>
+            {DEFAULT_FILTERS.map((filter) => (
+              <span key={filter.labelKey} className={styles.inlineChip}>
+                {formatFilterLabel(filter.labelKey)}
+              </span>
+            ))}
+          </div>
+        </div>
+        <button type="button" onClick={handleAddFilters} disabled={isPending}>
+          Add filters
+        </button>
+      </div>
+      {toast ? (
+        <p className={`${styles.feedback} ${toast.kind === "error" ? styles.feedbackError : styles.feedbackSuccess}`}>
+          {toast.text}
+        </p>
+      ) : (
+        <p className={styles.feedback}>Changes sync directly to Supabase. Adjustments will inform all future recommendations.</p>
+      )}
+    </section>
+  );
+}

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -1,0 +1,25 @@
+export type FilterDefinition = {
+  labelKey: string;
+  label: string;
+  defaultIntensity: number;
+};
+
+export const DEFAULT_FILTERS: FilterDefinition[] = [
+  { labelKey: "language", label: "Language", defaultIntensity: 5 },
+  { labelKey: "mature_themes", label: "Mature Themes", defaultIntensity: 5 },
+  { labelKey: "scary", label: "Scary", defaultIntensity: 5 },
+  { labelKey: "sex_nudity", label: "Sex & Nudity", defaultIntensity: 4 },
+  { labelKey: "substance", label: "Substance", defaultIntensity: 4 },
+  { labelKey: "violence", label: "Violence", defaultIntensity: 5 },
+];
+
+export function formatFilterLabel(labelKey: string): string {
+  const preset = DEFAULT_FILTERS.find((f) => f.labelKey === labelKey);
+  if (preset) return preset.label;
+  return labelKey
+    .split(/[_\-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+

--- a/lib/households.ts
+++ b/lib/households.ts
@@ -1,0 +1,88 @@
+import { createClient } from "@/lib/supabase/server";
+
+type RawHouseholdMembership = {
+  id: string;
+  user_id: string;
+  display_name: string | null;
+  household_id: string;
+  households?: { name: string | null } | null;
+};
+
+type RawHouseholdMember = {
+  id: string;
+  display_name: string | null;
+  birthday: string | null;
+  user_email: string | null;
+};
+
+export type ActiveHouseholdContext = {
+  user: { id: string; email?: string | null };
+  membershipId: string;
+  displayName: string | null;
+  householdId: string;
+  householdName: string | null;
+};
+
+export type HouseholdMember = {
+  id: string;
+  displayName: string | null;
+  birthday: string | null;
+  email: string | null;
+};
+
+export async function getActiveHouseholdContext(): Promise<ActiveHouseholdContext | null> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from("household_members")
+    .select("id, user_id, display_name, household_id, households(name)")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle<RawHouseholdMembership>();
+
+  if (error || !data) return null;
+
+  return {
+    user: { id: user.id, email: user.email },
+    membershipId: data.id,
+    displayName: data.display_name,
+    householdId: data.household_id,
+    householdName: data.households?.name ?? null,
+  };
+}
+
+export async function requireActiveHouseholdContext(): Promise<ActiveHouseholdContext> {
+  const context = await getActiveHouseholdContext();
+  if (!context) {
+    throw new Error("No active household context");
+  }
+  return context;
+}
+
+export async function listHouseholdMembers(householdId: string): Promise<HouseholdMember[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("household_members")
+    .select("id, display_name, birthday, user_email")
+    .eq("household_id", householdId)
+    .order("display_name", { ascending: true })
+    .returns<RawHouseholdMember[]>();
+
+  if (error) {
+    // If the table is missing or the user has no access yet, surface an empty list.
+    if ((error as { code?: string }).code === "42P01") {
+      return [];
+    }
+    throw error;
+  }
+
+  return (data ?? []).map((member) => ({
+    id: member.id,
+    displayName: member.display_name,
+    birthday: member.birthday,
+    email: member.user_email,
+  }));
+}

--- a/types/db.ts
+++ b/types/db.ts
@@ -10,3 +10,48 @@ export type CatalogRow = {
   providers: { service: string; link?: string | null; last_checked_at?: string }[];
 };
 
+export type HouseholdFilterLimit = {
+  household_id: string | null;
+  label_key: string;
+  hard_no: boolean;
+  max_intensity: number;
+};
+
+export type ChatHistoryRow = {
+  id: string;
+  created_at: string;
+  household_id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  metadata: Record<string, unknown> | null;
+};
+
+export type HouseholdMemberRow = {
+  id: string;
+  household_id: string;
+  display_name: string | null;
+  birthday: string | null;
+  user_email: string | null;
+};
+
+export type RecommendationLink = { label: string; url: string };
+
+export type RecommendationMovie = {
+  movieId: string;
+  title: string;
+  overview?: string | null;
+  posterUrl?: string | null;
+  releaseYear?: number | null;
+  runtimeMinutes?: number | null;
+  mpaaRating?: string | null;
+  links?: RecommendationLink[];
+};
+
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  createdAt: string;
+  pending?: boolean;
+  recommendations?: RecommendationMovie[];
+};


### PR DESCRIPTION
## Summary
- replace the catalog landing page with a dark themed household chat surface backed by new chat components and proxy API routes for N8n
- introduce a Supabase-driven preferences page with client-side editing, bulk actions, and reusable filter utilities
- refresh the global layout/theme, add authentication-friendly login styling, and configure ESLint for the Next.js project

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc7ed5a4ac832fa9247e6cc4a7d66a