### PR TITLE
Add initial signup onboarding flow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               {user ? (
                 <span className="badge">{user.email ?? "Signed in"}</span>
               ) : (
-                <Link href="/login">Sign in</Link>
+                <>
+                  <Link href="/login">Sign in</Link>
+                  <Link href="/signup">Sign up</Link>
+                </>
               )}
             </nav>
           </header>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { sendMagicLink } from "./actions";
 
 export default function LoginPage() {
@@ -15,6 +16,9 @@ export default function LoginPage() {
       </form>
       <p style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>
         Check your inbox and open the link on this device.
+      </p>
+      <p style={{ fontSize: "0.85rem", color: "var(--text-muted)", marginTop: "0.3rem" }}>
+        New here? <Link href="/signup">Create your family account</Link>
       </p>
     </div>
   );

--- a/app/signup/actions.ts
+++ b/app/signup/actions.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type SignupFormState =
+  | { status: "idle" }
+  | { status: "success"; message: string }
+  | { status: "error"; message: string };
+
+export const initialSignupState: SignupFormState = { status: "idle" };
+
+function normalizeInput(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isValidDate(value: string): boolean {
+  if (!value) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return false;
+  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month && date.getUTCDate() === day;
+}
+
+export async function startSignup(
+  _prevState: SignupFormState,
+  formData: FormData
+): Promise<SignupFormState> {
+  const email = normalizeInput(formData.get("email"));
+  const profileName = normalizeInput(formData.get("profileName"));
+  const householdName = normalizeInput(formData.get("householdName"));
+  const birthday = normalizeInput(formData.get("birthday"));
+
+  if (!email) {
+    return { status: "error", message: "Please enter an email address." };
+  }
+
+  if (!profileName) {
+    return { status: "error", message: "Let us know the name we should use for your profile." };
+  }
+
+  if (!householdName) {
+    return { status: "error", message: "Choose a household name to get everyone organized." };
+  }
+
+  if (!birthday) {
+    return { status: "error", message: "We’d love to know your birthday to tailor picks for you." };
+  }
+
+  if (!isValidDate(birthday)) {
+    return { status: "error", message: "Birthdays should be in YYYY-MM-DD format." };
+  }
+
+  const supabase = createClient();
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: {
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"}/auth/callback`,
+      data: {
+        onboarding_profile_name: profileName,
+        onboarding_household_name: householdName,
+        onboarding_birthday: birthday,
+      },
+      shouldCreateUser: true,
+    },
+  });
+
+  if (error) {
+    return { status: "error", message: error.message };
+  }
+
+  return {
+    status: "success",
+    message: "Check your inbox for a magic link to complete your sign up.",
+  };
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import SignupForm from "./signup-form";
+
+export const metadata = { title: "Join Family Movie Night" };
+
+export default function SignupPage() {
+  return (
+    <div className="card" style={{ maxWidth: 520, margin: "3.5rem auto", padding: "2rem", display: "grid", gap: "1.75rem" }}>
+      <div style={{ display: "grid", gap: "0.6rem" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.6rem" }}>
+          <span style={{ fontSize: "1.5rem" }} role="img" aria-hidden>
+            ✨
+          </span>
+          <p style={{ margin: 0, fontSize: "0.85rem", letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--text-muted)" }}>
+            Welcome
+          </p>
+        </div>
+        <h1 style={{ margin: 0 }}>Create your family hub</h1>
+        <p style={{ color: "var(--text-muted)", margin: 0 }}>
+          We’ll email you a secure magic link. Before we do, tell us a bit about who’s watching so we can curate picks
+          that feel just right.
+        </p>
+      </div>
+      <SignupForm />
+      <p style={{ margin: 0, textAlign: "center", fontSize: "0.9rem", color: "var(--text-muted)" }}>
+        Already have an account? <Link href="/login">Sign in</Link>
+      </p>
+    </div>
+  );
+}

--- a/app/signup/signup-form.tsx
+++ b/app/signup/signup-form.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import { initialSignupState, startSignup, type SignupFormState } from "./actions";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? "Sending magic link…" : "Send magic link"}
+    </button>
+  );
+}
+
+const helperStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "0.8rem",
+  color: "var(--text-muted)",
+};
+
+const fieldsetStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.45rem",
+};
+
+export default function SignupForm() {
+  const [state, formAction] = useFormState<SignupFormState, FormData>(startSignup, initialSignupState);
+
+  return (
+    <form action={formAction} style={{ display: "grid", gap: "1rem" }}>
+      <fieldset style={fieldsetStyle}>
+        <label htmlFor="email">Email</label>
+        <input id="email" name="email" type="email" placeholder="you@example.com" required />
+        <p style={helperStyle}>We’ll send all movie night updates here.</p>
+      </fieldset>
+
+      <fieldset style={fieldsetStyle}>
+        <label htmlFor="profileName">Profile name</label>
+        <input id="profileName" name="profileName" type="text" placeholder="Jamie" autoComplete="name" required />
+        <p style={helperStyle}>This is how we’ll greet you in chats and recommendations.</p>
+      </fieldset>
+
+      <fieldset style={fieldsetStyle}>
+        <label htmlFor="birthday">Birthday</label>
+        <input id="birthday" name="birthday" type="date" required max={new Date().toISOString().slice(0, 10)} />
+        <p style={helperStyle}>We use birthdays to tailor age-appropriate picks.</p>
+      </fieldset>
+
+      <fieldset style={fieldsetStyle}>
+        <label htmlFor="householdName">Household name</label>
+        <input id="householdName" name="householdName" type="text" placeholder="The Parkers" required />
+        <p style={helperStyle}>Pick something your whole crew will recognize.</p>
+      </fieldset>
+
+      <div style={{ display: "grid", gap: "0.6rem" }}>
+        <SubmitButton />
+        {state.status === "error" && (
+          <p role="alert" style={{ ...helperStyle, color: "var(--danger)" }}>
+            {state.message}
+          </p>
+        )}
+        {state.status === "success" && (
+          <p role="status" style={{ ...helperStyle, color: "var(--success)" }}>
+            {state.message}
+          </p>
+        )}
+        <p style={{ ...helperStyle, textAlign: "center" }}>
+          By continuing you agree to receive a one-time email to finish creating your account.
+        </p>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated signup page that guides new families through entering profile, birthday, and household details
- persist onboarding details via the magic-link flow and provide contextual feedback in the UI
- surface entry points to the signup experience from site navigation and the existing sign-in page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cca8dfb4d0832fa4524fe0e1fcf838