### PR TITLE
Handle Supabase cookie mutations safely on the server

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,24 +1,40 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
+function getEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
 export function createClient() {
   const cookieStore = cookies();
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: "", ...options });
-        },
+
+  const supabaseUrl = getEnvVar("NEXT_PUBLIC_SUPABASE_URL");
+  const supabaseAnonKey = getEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
       },
-    }
-  );
+      set(name: string, value: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value, ...options });
+        } catch (error) {
+          console.warn("Failed to set Supabase auth cookie", { name, error });
+        }
+      },
+      remove(name: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value: "", ...options });
+        } catch (error) {
+          console.warn("Failed to clear Supabase auth cookie", { name, error });
+        }
+      },
+    },
+  });
 }
 


### PR DESCRIPTION
## Summary
- guard Supabase client creation with required environment variables
- wrap Supabase cookie mutations so read-only request contexts no longer throw during renders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6523d1cc832f831eca3a7881a3b9