### PR TITLE
Add verbose logging for signup flow troubleshooting

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 function getEnvVar(name: string): string {
   const value = process.env[name];
   if (!value) {
+    console.error("[supabase] Missing required environment variable", { name });
     throw new Error(`Missing required environment variable: ${name}`);
   }
   return value;
@@ -11,17 +12,27 @@ function getEnvVar(name: string): string {
 
 export function createClient() {
   const cookieStore = cookies();
+  console.log("[supabase] Creating server client (server-side)", {
+    hasCookieStore: Boolean(cookieStore),
+  });
 
   const supabaseUrl = getEnvVar("NEXT_PUBLIC_SUPABASE_URL");
   const supabaseAnonKey = getEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY");
 
+  console.log("[supabase] Environment variables loaded", {
+    supabaseUrlLength: supabaseUrl.length,
+    anonKeyLength: supabaseAnonKey.length,
+  });
+
   return createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
       get(name: string) {
+        console.log("[supabase] Reading cookie", { name });
         return cookieStore.get(name)?.value;
       },
       set(name: string, value: string, options: CookieOptions) {
         try {
+          console.log("[supabase] Setting cookie", { name, hasValue: Boolean(value), options });
           cookieStore.set({ name, value, ...options });
         } catch (error) {
           console.warn("Failed to set Supabase auth cookie", { name, error });
@@ -29,6 +40,7 @@ export function createClient() {
       },
       remove(name: string, options: CookieOptions) {
         try {
+          console.log("[supabase] Removing cookie", { name, options });
           cookieStore.set({ name, value: "", ...options });
         } catch (error) {
           console.warn("Failed to clear Supabase auth cookie", { name, error });


### PR DESCRIPTION
## Summary
- add detailed console logging throughout the signup server action to understand validation results and Supabase interactions
- expand Supabase server client logging to capture environment configuration and cookie lifecycle events

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd8c24b768832fa7650c2c25158512