### PR TITLE
Add Supabase env fallback configuration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,10 @@
 # Supabase (Project Settings → API)
+# Either prefix works: use NEXT_PUBLIC_* for browser access, or SUPABASE_* to keep
+# the values server-side only. You can also set both if needed.
 NEXT_PUBLIC_SUPABASE_URL=https://YOUR-PROJECT-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=ey...
+# SUPABASE_URL=https://YOUR-PROJECT-ref.supabase.co
+# SUPABASE_ANON_KEY=ey...
 
 # Optional: only needed if you want a server-only admin client for CRON/etc.
 SUPABASE_SERVICE_ROLE_KEY=ey... # DO NOT expose to client

--- a/app/signup/actions.ts
+++ b/app/signup/actions.ts
@@ -69,13 +69,17 @@ export async function startSignup(
     return { status: "error", message: "Birthdays should be in YYYY-MM-DD format." };
   }
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const supabaseAnonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey) {
     console.error("Supabase environment variables are missing. Cannot start signup.", {
-      hasUrl: Boolean(supabaseUrl),
-      hasAnonKey: Boolean(supabaseAnonKey),
+      hasPublicUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+      hasServerUrl: Boolean(process.env.SUPABASE_URL),
+      hasPublicAnonKey: Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+      hasServerAnonKey: Boolean(process.env.SUPABASE_ANON_KEY),
     });
     return {
       status: "error",


### PR DESCRIPTION
## Summary
- allow the Supabase server client to fall back to server-only env variables when the public ones are missing
- update the signup pre-flight guard to recognize either env var prefix and keep the friendly retry message when both are absent
- document in the sample env file that either prefix is supported for Supabase credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd985c2220832f8dae6603280b48db