### PR TITLE
Switch to basic authentication for default preview user

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,19 +1,21 @@
 "use server";
 
+import { getAuthenticatedUser } from "@/lib/auth/server";
 import { createClient } from "@/lib/supabase/server";
 
 export async function logWatch(movieId: string) {
   const supabase = createClient();
 
   // Get session and household membership (for beta, we’ll assume the user’s first household)
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
   if (!user) return { ok: false, error: "Not signed in" };
 
   // Fetch a household the user belongs to
   const { data: hm, error: hmErr } = await supabase
     .from("household_members")
-    .select("household_id,id")
-    .eq("user_id", user.id)
+    .select("household_id,id,user_id")
+    .eq("user_email", user.email)
+    .order("created_at", { ascending: true })
     .limit(1)
     .maybeSingle();
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getAuthenticatedUser, getUnauthorizedResponseHeaders } from "@/lib/auth/server";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveHouseholdContext } from "@/lib/households";
 import type { RecommendationMovie } from "@/types/db";
@@ -40,11 +41,15 @@ async function persistMessage(
 }
 
 export async function POST(request: NextRequest) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
   if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, {
+      status: 401,
+      headers: getUnauthorizedResponseHeaders(),
+    });
   }
+
+  const supabase = createClient();
 
   let body: ChatRequestPayload;
   try {

--- a/app/api/log-movie/route.ts
+++ b/app/api/log-movie/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getAuthenticatedUser, getUnauthorizedResponseHeaders } from "@/lib/auth/server";
 import { getActiveHouseholdContext } from "@/lib/households";
 
 type LogMoviePayload = {
@@ -11,10 +11,12 @@ type LogMoviePayload = {
 };
 
 export async function POST(request: NextRequest) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
   if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, {
+      status: 401,
+      headers: getUnauthorizedResponseHeaders(),
+    });
   }
 
   let body: LogMoviePayload;

--- a/app/api/recommendations/do-not-recommend/route.ts
+++ b/app/api/recommendations/do-not-recommend/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+import { getAuthenticatedUser, getUnauthorizedResponseHeaders } from "@/lib/auth/server";
 import { getActiveHouseholdContext } from "@/lib/households";
 
 type BlockPayload = {
@@ -8,10 +8,12 @@ type BlockPayload = {
 };
 
 export async function POST(request: NextRequest) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
   if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthorized" }, {
+      status: 401,
+      headers: getUnauthorizedResponseHeaders(),
+    });
   }
 
   let body: BlockPayload;

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
-
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const code = url.searchParams.get("code");
   if (!code) return NextResponse.redirect(new URL("/", req.url));
 
-  const supabase = createClient();
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
-  // After exchange, the auth cookies are set
   const redirectTo = url.searchParams.get("next") || "/";
   return NextResponse.redirect(new URL(redirectTo, req.url));
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,11 @@
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/server";
+import { getAuthenticatedUser } from "@/lib/auth/server";
 import "./globals.css";
 
 export const metadata = { title: "Family Movies" };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
 
   return (
     <html lang="en">

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,20 +1,9 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-
-export async function sendMagicLink(formData: FormData) {
-  const email = String(formData.get("email") ?? "").trim();
-  if (!email) return { ok: false, error: "Email required" };
-
-  const supabase = createClient();
-  const { error } = await supabase.auth.signInWithOtp({
-    email,
-    options: {
-      emailRedirectTo: `${process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"}/auth/callback`
-    }
-  });
-
-  if (error) return { ok: false, error: error.message };
-  return { ok: true };
+export async function sendMagicLink() {
+  return {
+    ok: false,
+    error: "Magic link sign-in is disabled while basic authentication is active.",
+  } as const;
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,25 +1,29 @@
 import Link from "next/link";
-import { sendMagicLink } from "./actions";
 
 export default function LoginPage() {
   return (
-    <div className="card" style={{ maxWidth: 420, margin: "3rem auto", display: "grid", gap: "1rem" }}>
+    <div className="card" style={{ maxWidth: 520, margin: "3rem auto", display: "grid", gap: "1rem" }}>
       <div>
-        <h2 style={{ margin: 0 }}>Sign in</h2>
+        <h2 style={{ margin: 0 }}>Basic authentication enabled</h2>
         <p style={{ color: "var(--text-muted)", marginTop: "0.4rem" }}>
-          We’ll email you a one-time magic link so you can pick up where you left off.
+          Sign in using the browser prompt with the credentials <code>admin</code> / <code>movies</code>. Once
+          authenticated, you&rsquo;ll be treated as <code>eriknewby@icloud.com</code> so you can browse the existing
+          household setup.
         </p>
       </div>
-      <form action={sendMagicLink} style={{ display: "grid", gap: "0.75rem" }}>
-        <input type="email" name="email" placeholder="you@example.com" required />
-        <button type="submit">Send magic link</button>
-      </form>
-      <p style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>
-        Check your inbox and open the link on this device.
+      <p style={{ fontSize: "0.9rem", color: "var(--text-muted)" }}>
+        If you don&rsquo;t see the prompt, refresh the page or navigate directly to any protected area (for example the
+        {" "}
+        <Link href="/">chat</Link>) and your browser will ask for the credentials.
       </p>
-      <p style={{ fontSize: "0.85rem", color: "var(--text-muted)", marginTop: "0.3rem" }}>
-        New here? <Link href="/signup">Create your family account</Link>
-      </p>
+      <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+        <Link href="/">
+          <button type="button">Return to chat</button>
+        </Link>
+        <Link href="/preferences">
+          <button type="button" className="secondary">View preferences</button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import ChatShell from "@/components/chat/chat-shell";
+import { getAuthenticatedUser } from "@/lib/auth/server";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveHouseholdContext, listHouseholdMembers } from "@/lib/households";
 import type { ChatHistoryRow, HouseholdFilterLimit, RecommendationMovie } from "@/types/db";
@@ -52,18 +53,18 @@ function mapRecommendations(metadata: Record<string, unknown> | null): Recommend
 }
 
 export default async function Page() {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
 
   if (!user) {
     return (
       <section className="card" style={{ maxWidth: 420, margin: "4rem auto" }}>
         <h2 style={{ marginTop: 0 }}>Sign in required</h2>
         <p style={{ color: "var(--text-muted)" }}>
-          Sign in with your email to chat with the family movie assistant and manage your filters.
+          Sign in with the shared credentials{" "}(<code>admin</code> / <code>movies</code>) to chat with the family
+          movie assistant and manage your filters.
         </p>
         <a href="/login">
-          <button type="button">Go to login</button>
+          <button type="button">View sign-in instructions</button>
         </a>
       </section>
     );

--- a/app/preferences/page.tsx
+++ b/app/preferences/page.tsx
@@ -1,4 +1,5 @@
 import PreferencesPanel from "@/components/preferences/preferences-panel";
+import { getAuthenticatedUser } from "@/lib/auth/server";
 import { createClient } from "@/lib/supabase/server";
 import { getActiveHouseholdContext } from "@/lib/households";
 import type { HouseholdFilterLimit } from "@/types/db";
@@ -22,18 +23,18 @@ async function fetchFilters(householdId: string): Promise<HouseholdFilterLimit[]
 }
 
 export default async function PreferencesPage() {
-  const supabase = createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const user = getAuthenticatedUser();
 
   if (!user) {
     return (
       <section className="card" style={{ maxWidth: 420, margin: "4rem auto" }}>
         <h2 style={{ marginTop: 0 }}>Sign in to manage filters</h2>
         <p style={{ color: "var(--text-muted)" }}>
-          Your household filters live in Supabase. Sign in first so we can load and update them securely.
+          Your household filters live in Supabase. Sign in with the shared credentials{" "}
+          (<code>admin</code> / <code>movies</code>) so we can load and update them securely.
         </p>
         <a href="/login">
-          <button type="button">Go to login</button>
+          <button type="button">View sign-in instructions</button>
         </a>
       </section>
     );

--- a/app/signup/actions.ts
+++ b/app/signup/actions.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-
 export type SignupFormState =
   | { status: "idle" }
   | { status: "success"; message: string }
@@ -9,130 +7,12 @@ export type SignupFormState =
 
 export const initialSignupState: SignupFormState = { status: "idle" };
 
-function normalizeInput(value: FormDataEntryValue | null): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function isValidDate(value: string): boolean {
-  if (!value) return false;
-  const date = new Date(`${value}T00:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-  const [year, month, day] = value.split("-").map(Number);
-  if (!year || !month || !day) return false;
-  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month && date.getUTCDate() === day;
-}
-
 export async function startSignup(
   _prevState: SignupFormState,
-  formData: FormData
+  _formData: FormData
 ): Promise<SignupFormState> {
-  const receivedFields = Array.from(formData.keys());
-  console.log("[signup] startSignup invoked", {
-    receivedFields,
-    fieldCount: receivedFields.length,
-  });
-
-  const email = normalizeInput(formData.get("email"));
-  const profileName = normalizeInput(formData.get("profileName"));
-  const householdName = normalizeInput(formData.get("householdName"));
-  const birthday = normalizeInput(formData.get("birthday"));
-
-  console.log("[signup] Normalized input", {
-    emailLength: email.length,
-    hasProfileName: Boolean(profileName),
-    householdNameLength: householdName.length,
-    birthdayLength: birthday.length,
-  });
-
-  if (!email) {
-    console.warn("[signup] Missing email address");
-    return { status: "error", message: "Please enter an email address." };
-  }
-
-  if (!profileName) {
-    console.warn("[signup] Missing profile name");
-    return { status: "error", message: "Let us know the name we should use for your profile." };
-  }
-
-  if (!householdName) {
-    console.warn("[signup] Missing household name");
-    return { status: "error", message: "Choose a household name to get everyone organized." };
-  }
-
-  if (!birthday) {
-    console.warn("[signup] Missing birthday");
-    return { status: "error", message: "We’d love to know your birthday to tailor picks for you." };
-  }
-
-  if (!isValidDate(birthday)) {
-    console.warn("[signup] Invalid birthday format", { birthdayLength: birthday.length });
-    return { status: "error", message: "Birthdays should be in YYYY-MM-DD format." };
-  }
-
-  const supabaseUrl =
-    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-  const supabaseAnonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    console.error("Supabase environment variables are missing. Cannot start signup.", {
-      hasPublicUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
-      hasServerUrl: Boolean(process.env.SUPABASE_URL),
-      hasPublicAnonKey: Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
-      hasServerAnonKey: Boolean(process.env.SUPABASE_ANON_KEY),
-    });
-    return {
-      status: "error",
-      message: "We couldn't send the magic link right now. Please try again later.",
-    };
-  }
-
-  try {
-    console.log("[signup] Creating Supabase client", {
-      supabaseUrlLength: supabaseUrl.length,
-      anonKeyLength: supabaseAnonKey.length,
-    });
-
-    const supabase = createClient();
-    console.log("[signup] Supabase client created successfully");
-
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000"}/auth/callback`,
-        data: {
-          onboarding_profile_name: profileName,
-          onboarding_household_name: householdName,
-          onboarding_birthday: birthday,
-        },
-        shouldCreateUser: true,
-      },
-    });
-
-    console.log("[signup] signInWithOtp response", {
-      hasError: Boolean(error),
-      emailDomain: email.split("@")[1] ?? "unknown",
-    });
-
-    if (error) {
-      console.error("Supabase failed to send signup magic link", error);
-      return { status: "error", message: error.message };
-    }
-  } catch (error) {
-    console.error("Unexpected error while starting signup", error);
-    if (error instanceof Error) {
-      console.error("[signup] Error stack", error.stack);
-    }
-    return {
-      status: "error",
-      message: "We couldn't send the magic link right now. Please try again later.",
-    };
-  }
-
-  console.log("[signup] Signup flow completed successfully", { emailDomain: email.split("@")[1] ?? "unknown" });
-
   return {
-    status: "success",
-    message: "Check your inbox for a magic link to complete your sign up.",
+    status: "error",
+    message: "Email sign-up is disabled while basic authentication is enabled.",
   };
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,4 @@
 import Link from "next/link";
-import SignupForm from "./signup-form";
-
 export const metadata = { title: "Join Family Movie Night" };
 
 export default function SignupPage() {
@@ -15,16 +13,21 @@ export default function SignupPage() {
             Welcome
           </p>
         </div>
-        <h1 style={{ margin: 0 }}>Create your family hub</h1>
+        <h1 style={{ margin: 0 }}>Preview mode</h1>
         <p style={{ color: "var(--text-muted)", margin: 0 }}>
-          We’ll email you a secure magic link. Before we do, tell us a bit about who’s watching so we can curate picks
-          that feel just right.
+          Email-based sign-up is temporarily disabled while basic authentication is active. Use the shared credentials
+          {" "}
+          <code>admin</code> / <code>movies</code> to explore the existing household as <code>eriknewby@icloud.com</code>.
         </p>
       </div>
-      <SignupForm />
-      <p style={{ margin: 0, textAlign: "center", fontSize: "0.9rem", color: "var(--text-muted)" }}>
-        Already have an account? <Link href="/login">Sign in</Link>
-      </p>
+      <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+        <Link href="/login">
+          <button type="button">View sign-in instructions</button>
+        </Link>
+        <Link href="/">
+          <button type="button" className="secondary">Return to chat</button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/lib/auth/basic.ts
+++ b/lib/auth/basic.ts
@@ -1,0 +1,59 @@
+const BASIC_AUTH_USER = process.env.BASIC_AUTH_USER ?? "admin";
+const BASIC_AUTH_PASSWORD = process.env.BASIC_AUTH_PASSWORD ?? process.env.BASIC_AUTH_PASS ?? "movies";
+const DEFAULT_USER_EMAIL = process.env.BASIC_AUTH_DEFAULT_EMAIL ?? "eriknewby@icloud.com";
+const DEFAULT_USER_ID = process.env.BASIC_AUTH_DEFAULT_USER_ID ?? "basic-auth-user";
+
+function decodeBase64(value: string): string {
+  if (typeof atob === "function") {
+    try {
+      return atob(value);
+    } catch (error) {
+      console.warn("[auth] Failed to decode using atob", error);
+    }
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf-8");
+  }
+  throw new Error("No base64 decoder available in this environment");
+}
+
+export type BasicCredentials = { username: string; password: string };
+
+export function parseBasicAuthorizationHeader(headerValue: string | null): BasicCredentials | null {
+  if (!headerValue) return null;
+  const [scheme, encoded] = headerValue.split(" ");
+  if (!scheme || scheme.toLowerCase() !== "basic" || !encoded) return null;
+  try {
+    const decoded = decodeBase64(encoded);
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex === -1) return null;
+    return {
+      username: decoded.slice(0, separatorIndex),
+      password: decoded.slice(separatorIndex + 1),
+    };
+  } catch (error) {
+    console.warn("[auth] Failed to parse basic auth header", error);
+    return null;
+  }
+}
+
+export type AuthenticatedBasicUser = {
+  id: string;
+  email: string;
+  username: string;
+};
+
+export function getUserFromCredentials(credentials: BasicCredentials | null): AuthenticatedBasicUser | null {
+  if (!credentials) return null;
+  if (credentials.username !== BASIC_AUTH_USER) return null;
+  if (credentials.password !== BASIC_AUTH_PASSWORD) return null;
+  return {
+    id: DEFAULT_USER_ID,
+    email: DEFAULT_USER_EMAIL,
+    username: credentials.username,
+  };
+}
+
+export function getBasicAuthChallenge(): string {
+  return 'Basic realm="Family Movies"';
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,0 +1,31 @@
+import { headers } from "next/headers";
+import {
+  getBasicAuthChallenge,
+  getUserFromCredentials,
+  parseBasicAuthorizationHeader,
+  type AuthenticatedBasicUser,
+} from "./basic";
+
+export type AuthenticatedUser = AuthenticatedBasicUser;
+
+export function getAuthenticatedUser(): AuthenticatedUser | null {
+  const headerStore = headers();
+  const authorization = headerStore.get("authorization");
+  return getUserFromCredentials(parseBasicAuthorizationHeader(authorization));
+}
+
+export function assertAuthenticatedUser(): AuthenticatedUser {
+  const user = getAuthenticatedUser();
+  if (!user) {
+    const challenge = getBasicAuthChallenge();
+    const error = new Error("Basic authentication required");
+    (error as { status?: number }).status = 401;
+    (error as { headers?: Record<string, string> }).headers = { "WWW-Authenticate": challenge };
+    throw error;
+  }
+  return user;
+}
+
+export function getUnauthorizedResponseHeaders(): Record<string, string> {
+  return { "WWW-Authenticate": getBasicAuthChallenge() };
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -35,14 +35,18 @@ export function createClient() {
   });
 
   const supabaseUrl = getEnvVar("NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL");
-  const supabaseAnonKey = getEnvVar(
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-    "SUPABASE_ANON_KEY"
-  );
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const supabaseAnonKey =
+    supabaseServiceRoleKey ??
+    getEnvVar(
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "SUPABASE_ANON_KEY"
+    );
 
   console.log("[supabase] Environment variables loaded", {
     supabaseUrlLength: supabaseUrl.length,
     anonKeyLength: supabaseAnonKey.length,
+    usingServiceRole: Boolean(supabaseServiceRoleKey),
   });
 
   return createServerClient(supabaseUrl, supabaseAnonKey, {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getBasicAuthChallenge, getUserFromCredentials, parseBasicAuthorizationHeader } from "./lib/auth/basic";
+
+const PUBLIC_PATHS = [/^\/favicon\.ico$/, /^\/robots\.txt$/, /^\/manifest\.webmanifest$/, /^\/sitemap\.xml$/];
+
+function isPublicPath(pathname: string): boolean {
+  if (pathname.startsWith("/_next")) return true;
+  if (pathname.startsWith("/api/auth")) return true;
+  return PUBLIC_PATHS.some((pattern) => pattern.test(pathname));
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (isPublicPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  const credentials = getUserFromCredentials(
+    parseBasicAuthorizationHeader(request.headers.get("authorization"))
+  );
+
+  if (credentials) {
+    return NextResponse.next();
+  }
+
+  return new NextResponse("Authentication required", {
+    status: 401,
+    headers: { "WWW-Authenticate": getBasicAuthChallenge() },
+  });
+}
+
+export const config = {
+  matcher: "/:path*",
+};


### PR DESCRIPTION
## Summary
- enforce HTTP basic authentication with the shared `admin`/`movies` credentials and automatically treat the session as eriknewby@icloud.com
- replace Supabase auth calls with basic-auth aware helpers, update onboarding flows, and disable email-based login/signup during preview mode
- allow the server Supabase client to use a service role key when available for database access without user sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda4c62004832f935cb09de53af7d6