### PR TITLE
Rename household member birthday field to birthdate

### DIFF
--- a/app/signup/signup-form.tsx
+++ b/app/signup/signup-form.tsx
@@ -42,8 +42,14 @@ export default function SignupForm() {
       </fieldset>
 
       <fieldset style={fieldsetStyle}>
-        <label htmlFor="birthday">Birthday</label>
-        <input id="birthday" name="birthday" type="date" required max={new Date().toISOString().slice(0, 10)} />
+        <label htmlFor="birthdate">Birthday</label>
+        <input
+          id="birthdate"
+          name="birthdate"
+          type="date"
+          required
+          max={new Date().toISOString().slice(0, 10)}
+        />
         <p style={helperStyle}>We use birthdays to tailor age-appropriate picks.</p>
       </fieldset>
 

--- a/lib/households.ts
+++ b/lib/households.ts
@@ -12,7 +12,7 @@ type RawHouseholdMembership = {
 type RawHouseholdMember = {
   id: string;
   display_name: string | null;
-  birthday: string | null;
+  birthdate: string | null;
   user_email: string | null;
 };
 
@@ -27,7 +27,7 @@ export type ActiveHouseholdContext = {
 export type HouseholdMember = {
   id: string;
   displayName: string | null;
-  birthday: string | null;
+  birthdate: string | null;
   email: string | null;
 };
 
@@ -67,7 +67,7 @@ export async function listHouseholdMembers(householdId: string): Promise<Househo
   const supabase = createClient();
   const { data, error } = await supabase
     .from("household_members")
-    .select("id, display_name, birthday, user_email")
+    .select("id, display_name, birthdate, user_email")
     .eq("household_id", householdId)
     .order("display_name", { ascending: true })
     .returns<RawHouseholdMember[]>();
@@ -83,7 +83,7 @@ export async function listHouseholdMembers(householdId: string): Promise<Househo
   return (data ?? []).map((member) => ({
     id: member.id,
     displayName: member.display_name,
-    birthday: member.birthday,
+    birthdate: member.birthdate,
     email: member.user_email,
   }));
 }

--- a/types/db.ts
+++ b/types/db.ts
@@ -31,7 +31,7 @@ export type HouseholdMemberRow = {
   id: string;
   household_id: string;
   display_name: string | null;
-  birthday: string | null;
+  birthdate: string | null;
   user_email: string | null;
 };
 


### PR DESCRIPTION
## Summary
- rename household member types and selection to use the birthdate column
- align db typings with the birthdate field
- update the signup form to submit birthdate data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb43495a4832f94c6fd30639b474c