### PR TITLE
Improve preferences saving UX

### DIFF
--- a/components/preferences/preferences-panel.module.css
+++ b/components/preferences/preferences-panel.module.css
@@ -76,9 +76,11 @@
 }
 
 .sliderRow output {
-  min-width: 2.2rem;
+  min-width: 6.5rem;
   text-align: right;
   font-weight: 600;
+  color: var(--accent);
+  font-size: 0.85rem;
 }
 
 .rangeRow input[type="range"] {
@@ -168,6 +170,48 @@
 
 .feedbackSuccess {
   color: var(--success);
+}
+
+.toastContainer {
+  position: fixed;
+  bottom: 1.6rem;
+  right: 1.6rem;
+  z-index: 20;
+}
+
+.toast {
+  padding: 0.75rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 24px rgba(5, 7, 13, 0.4);
+  background: rgba(15, 20, 32, 0.85);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toastSuccess {
+  color: var(--success);
+}
+
+.toastError {
+  color: var(--danger);
+}
+
+@media (max-width: 640px) {
+  .toastContainer {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    bottom: 1rem;
+  }
+
+  .toast {
+    border-radius: 0.9rem;
+  }
 }
 
 .emptyState {


### PR DESCRIPTION
## Summary
- replace numeric intensity output with descriptive labels and updated slider accessibility
- ensure optimistic filter updates stick by tracking pending Supabase signatures before syncing props
- add a floating toast confirmation that quietly acknowledges successful saves or surface errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc9f16428832f912a855fc258504a