### PR TITLE
Add diagnostic logging for Supabase filter updates

### DIFF
--- a/app/preferences/actions.ts
+++ b/app/preferences/actions.ts
@@ -6,6 +6,7 @@ import { requireActiveHouseholdContext } from "@/lib/households";
 import { DEFAULT_FILTERS } from "@/lib/filters";
 
 const DEFAULT_INTENSITY = 5;
+const DEBUG_PREFIX = "[preferences/actions]";
 
 type ActionResult = { ok: boolean; error?: string };
 
@@ -23,6 +24,22 @@ type BulkRemovePayload = {
   labels: string[];
 };
 
+function debug(message: string, details?: Record<string, unknown>) {
+  if (details) {
+    console.log(`${DEBUG_PREFIX} ${message}`, details);
+  } else {
+    console.log(`${DEBUG_PREFIX} ${message}`);
+  }
+}
+
+function debugError(message: string, details?: Record<string, unknown>) {
+  if (details) {
+    console.error(`${DEBUG_PREFIX} ${message}`, details);
+  } else {
+    console.error(`${DEBUG_PREFIX} ${message}`);
+  }
+}
+
 function revalidate() {
   revalidatePath("/preferences");
   revalidatePath("/");
@@ -39,28 +56,58 @@ function intensityGuard(value: number): number {
 }
 
 export async function updateFilter(payload: UpdatePayload): Promise<ActionResult> {
-  const labelKey = sanitizeLabel(payload.labelKey);
-  if (!labelKey) {
-    return { ok: false, error: "Label is required" };
+  debug("updateFilter invoked", { payload });
+
+  try {
+    const labelKey = sanitizeLabel(payload.labelKey);
+    if (!labelKey) {
+      debugError("updateFilter missing label", { payload });
+      return { ok: false, error: "Label is required" };
+    }
+
+    const { householdId } = await requireActiveHouseholdContext();
+    debug("updateFilter resolved household", { householdId, labelKey });
+
+    const supabase = createClient();
+    const response = await supabase
+      .from("household_filter_limits")
+      .upsert(
+        {
+          household_id: householdId,
+          label_key: labelKey,
+          hard_no: payload.hardNo,
+          max_intensity: intensityGuard(payload.maxIntensity),
+        },
+        { onConflict: "household_id,label_key" }
+      );
+
+    if (response.error) {
+      debugError("updateFilter supabase error", {
+        message: response.error.message,
+        code: (response.error as { code?: string }).code,
+        details: response.error.details,
+        hint: (response.error as { hint?: string }).hint,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      return { ok: false, error: response.error.message };
+    }
+
+    debug("updateFilter supabase success", {
+      householdId,
+      labelKey,
+      status: response.status,
+      statusText: response.statusText,
+    });
+
+    revalidate();
+    return { ok: true };
+  } catch (cause) {
+    debugError("updateFilter threw", {
+      cause,
+    });
+    return { ok: false, error: cause instanceof Error ? cause.message : "Unable to update filter" };
   }
-
-  const { householdId } = await requireActiveHouseholdContext();
-  const supabase = createClient();
-  const { error } = await supabase
-    .from("household_filter_limits")
-    .upsert({
-      household_id: householdId,
-      label_key: labelKey,
-      hard_no: payload.hardNo,
-      max_intensity: intensityGuard(payload.maxIntensity),
-    }, { onConflict: "household_id,label_key" });
-
-  if (error) {
-    return { ok: false, error: error.message };
-  }
-
-  revalidate();
-  return { ok: true };
 }
 
 export async function addFilters(payload: BulkAddPayload): Promise<ActionResult> {

--- a/components/preferences/preferences-panel.tsx
+++ b/components/preferences/preferences-panel.tsx
@@ -19,6 +19,7 @@ type PreferencesPanelProps = {
 type ToastState = { kind: "success" | "error"; text: string } | null;
 
 const DEFAULT_INTENSITY = 5;
+const DEBUG_PREFIX = "[preferences/panel]";
 const INTENSITY_DESCRIPTORS = [
   "None",
   "Trace",
@@ -117,13 +118,21 @@ export default function PreferencesPanel({ filters, householdName }: Preferences
     const fallback = cloneFilters(persistedFilters);
 
     startTransition(async () => {
+      console.log(`${DEBUG_PREFIX} attempting update`, {
+        labelKey,
+        maxIntensity: target.maxIntensity,
+        hardNo: target.hardNo,
+      });
       const result = await updateFilter({
         labelKey: target.labelKey,
         maxIntensity: target.maxIntensity,
         hardNo: target.hardNo,
       });
 
+      console.log(`${DEBUG_PREFIX} update result`, { labelKey, result });
+
       if (!result.ok) {
+        console.error(`${DEBUG_PREFIX} update failed`, { labelKey, error: result.error });
         setFilterRows(fallback);
         setPersistedFilters(fallback);
         setPendingSignature(null);


### PR DESCRIPTION
## Summary
- add reusable helpers that log when the server action resolves a household, succeeds, or returns an error while updating Supabase
- emit client-side console logs around filter saves so we can correlate UI interactions with the server action responses

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdea2d474c832fa69c8c58ff8a04fe