### PR TITLE
Normalize filter label keys before saving

### DIFF
--- a/components/preferences/preferences-panel.tsx
+++ b/components/preferences/preferences-panel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import styles from "./preferences-panel.module.css";
 import { addFilters, removeFilters, resetFilters, updateFilter } from "@/app/preferences/actions";
-import { DEFAULT_FILTERS, formatFilterLabel } from "@/lib/filters";
+import { DEFAULT_FILTERS, formatFilterLabel, normalizeFilterLabelKey } from "@/lib/filters";
 
 type FilterView = {
   labelKey: string;
@@ -53,7 +53,7 @@ function describeIntensity(value: number): string {
 function parseInputList(raw: string): string[] {
   return raw
     .split(/[\n,]+/)
-    .map((entry) => entry.trim())
+    .map((entry) => normalizeFilterLabelKey(entry))
     .filter(Boolean);
 }
 
@@ -254,9 +254,9 @@ export default function PreferencesPanel({ filters, householdName }: Preferences
     }
 
     const snapshot = cloneFilters(filterRows);
-    const existingKeys = new Set(snapshot.map((filter) => filter.labelKey.toLowerCase()));
-    const unique = Array.from(new Map(parsed.map((label) => [label.toLowerCase(), label])).values());
-    const newLabels = unique.filter((label) => !existingKeys.has(label.toLowerCase()));
+    const existingKeys = new Set(snapshot.map((filter) => filter.labelKey));
+    const unique = Array.from(new Set(parsed));
+    const newLabels = unique.filter((label) => !existingKeys.has(label));
 
     if (!newLabels.length) {
       setToast({ kind: "error", text: "Those filters already exist" });

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -13,12 +13,26 @@ export const DEFAULT_FILTERS: FilterDefinition[] = [
   { labelKey: "violence", label: "Violence", defaultIntensity: 5 },
 ];
 
+function normalizeLabelSegments(labelKey: string): string[] {
+  return labelKey
+    .split(/[_\-]+/)
+    .filter(Boolean);
+}
+
+export function normalizeFilterLabelKey(rawLabel: string): string {
+  const normalized = rawLabel
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return normalized;
+}
+
 export function formatFilterLabel(labelKey: string): string {
   const preset = DEFAULT_FILTERS.find((f) => f.labelKey === labelKey);
   if (preset) return preset.label;
-  return labelKey
-    .split(/[_\-]+/)
-    .filter(Boolean)
+  return normalizeLabelSegments(labelKey)
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(" ");
 }


### PR DESCRIPTION
## Summary
- normalize filter labels into slug-style keys before optimistic updates
- reuse the shared normalization when persisting filter changes to Supabase

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d09bcb0060832fbf970b73fe53586f